### PR TITLE
Additional validation for MoveAnalysisBox-observer

### DIFF
--- a/Observer/MoveAnalysisBox.php
+++ b/Observer/MoveAnalysisBox.php
@@ -60,6 +60,10 @@ class MoveAnalysisBox implements ObserverInterface
         }
 
         $analysisResultBlock = $block->getChildBlock('addressfactory_analysis_data');
+        if (!$analysisResultBlock) {
+            return;
+        }
+
         $analysisResultBlock->setData('template_should_display', true);
 
         $transport = $observer->getData('transport');


### PR DESCRIPTION
It seems like we have at least one block in our project that meets all the conditions that are validated in the MoveAnalysisBox-observer, down to
`$analysisResultBlock = $block->getChildBlock('addressfactory_analysis_data');`
 (https://github.com/netresearch/deutschepost-module-addressfactory-m2/blob/c1e27accf4ebc31895fefa5dca33b69430044dad/Observer/MoveAnalysisBox.php#L62C11-L62C11)
but is still not the proper block that contains the address-validation data.

In such a case `$analysisResultBlock = $block->getChildBlock('addressfactory_analysis_data')` returns `false`. 
Calling `$analysisResultBlock->setData('template_should_display', true)` then results in the following error:
`Error: Call to a member function setData() on bool in [...]/vendor/deutschepost/module-addressfactory-m2/Observer/MoveAnalysisBox.php:63`

The added validation makes sure that the second call is only performed if the proper child-block is present.
